### PR TITLE
修复「一个页面中多个图表」和「页面不阻塞滚动」两个页面无法二次进入的bug。

### DIFF
--- a/pages/move/index.js
+++ b/pages/move/index.js
@@ -21,9 +21,6 @@ Page({
           height: height
         });
         canvas.setChart(barChart);
-
-        // 将 barChart 绑定到 this，以供其他函数访问
-        this.barChart = barChart;
         barChart.setOption(getBarOption());
 
         return barChart;

--- a/pages/multiCharts/index.js
+++ b/pages/multiCharts/index.js
@@ -17,9 +17,6 @@ Page({
           height: height
         });
         canvas.setChart(barChart);
-
-        // 将 barChart 绑定到 this，以供其他函数访问
-        this.barChart = barChart;
         barChart.setOption(getBarOption());
 
         return barChart;
@@ -33,8 +30,6 @@ Page({
           height: height
         });
         canvas.setChart(scatterChart);
-
-        this.scatterChart = scatterChart;
         scatterChart.setOption(getScatterOption());
 
         return scatterChart;


### PR DESCRIPTION
绑定this后会导致二次进入某些页面后出现```JSON.stringify```的循环引用问题：
详见bug: https://github.com/ecomfe/echarts-for-weixin/issues/128
```
Converting circular structure to JSON
TypeError: Converting circular structure to JSON
    at JSON.stringify (<anonymous>)
    at Object.a [as publish] (http://127.0.0.1:55037/appservice/appservice:1228:8044)
    at c (http://127.0.0.1:55037/appservice/__dev__/WAService.js:16:7000)
    at t.sendData (http://127.0.0.1:55037/appservice/__dev__/WAService.js:16:7566)
    at z (http://127.0.0.1:55037/appservice/__dev__/WAService.js:16:4901)
    at Object.t.addView (http://127.0.0.1:55037/appservice/__dev__/WAService.js:16:6005)
    at Function.value (http://127.0.0.1:55037/appservice/__dev__/WAService.js:18:1346)
    at B (http://127.0.0.1:55037/appservice/__dev__/WAService.js:17:11379)
    at L (http://127.0.0.1:55037/appservice/__dev__/WAService.js:17:12665)
    at G (http://127.0.0.1:55037/appservice/__dev__/WAService.js:17:13986)
```
而且是在进入页面之前出现的，二级页面的生命周期函数没有被回调。
解决办法是删除data数据初始化过程中的chart绑定，比如：
```
this.barChart = barChart;
```
猜测是因为调用this的对象中发生了循环引用，由于不知道具体实现，无法得知深层原因；希望开发者能告知，以便从中学习，谢谢~


CHANG 3 MAY 2018
