### PR TITLE
feat: added triggerEvent support

### DIFF
--- a/ec-canvas/ec-canvas.js
+++ b/ec-canvas/ec-canvas.js
@@ -56,8 +56,15 @@ Component({
         if (typeof callback === 'function') {
           this.chart = callback(canvas, res.width, res.height);
         }
-        else if (this.data.ec && this.data.ec.onInit) {
+        else if (this.data.ec && typeof this.data.ec.onInit === 'function') {
           this.chart = this.data.ec.onInit(canvas, res.width, res.height);
+        }
+        else {
+          this.triggerEvent('init', {
+            canvas: canvas,
+            width: res.width,
+            height: res.height
+          });
         }
       }).exec();
     },
@@ -66,7 +73,7 @@ Component({
       if (!opt.canvasId) {
         opt.canvasId = this.data.canvasId;
       }
-      
+
       ctx.draw(true, () => {
         wx.canvasToTempFilePath(opt, this);
       });

--- a/pages/pie/index.js
+++ b/pages/pie/index.js
@@ -63,10 +63,13 @@ Page({
   },
   data: {
     ec: {
-      onInit: initChart
     }
   },
 
   onReady() {
+  },
+
+  echartInit (e) {
+    initChart(e.detail.canvas, e.detail.width, e.detail.height);
   }
 });

--- a/pages/pie/index.wxml
+++ b/pages/pie/index.wxml
@@ -1,4 +1,4 @@
 <!--index.wxml-->
 <view class="container">
-  <ec-canvas id="mychart-dom-pie" canvas-id="mychart-pie" ec="{{ ec }}"></ec-canvas>
+  <ec-canvas id="mychart-dom-pie" canvas-id="mychart-pie" ec="{{ ec }}" bind:init="echartInit"></ec-canvas>
 </view>


### PR DESCRIPTION
Passing a `onInit` function to a Component is not a best practice in Wechat Mini Application.
Currently passing function in data is not stable yet. I created two piece of [code snippets](https://developers.weixin.qq.com/miniprogram/dev/devtools/minicode.html) to indicate the issue.

```
wechatide://minicode/laRw2umk67Z7
wechatide://minicode/dqUXqumY67Z9
```

According the official teams words, this should be a bug for them, and will fix it in the new version code lib.

Actually [triggerEvent](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/events.html) is more suitable for this feature, and I suggest to update the doc, and  use `triggerEvent` in the new version.
