### PR TITLE
fix(ec-canvas.js): 针对lazyLoad的情况，防止init在视图层ready之前被触发

### DIFF
--- a/ec-canvas/ec-canvas.js
+++ b/ec-canvas/ec-canvas.js
@@ -26,13 +26,23 @@ Component({
       return;
     }
 
+    this._isReady = true;
     if (!this.data.ec.lazyLoad) {
       this.init();
+    } else { // 针对lazyLoad的 init 必须在ready之后
+      if (this._pendingInitCb) {
+        this.init(this._pendingInitCb);
+      }
     }
   },
 
   methods: {
     init: function (callback) {
+      if (!this._isReady) {
+        this._pendingInitCb = callback;
+        return;
+      }
+
       const version = wx.version.version.split('.').map(n => parseInt(n, 10));
       const isValid = version[0] > 1 || (version[0] === 1 && version[1] > 9)
         || (version[0] === 1 && version[1] === 9 && version[2] >= 91);


### PR DESCRIPTION
如果在ready之前调用（可能是通过property的observe函数触发）
会导致selectorQuery canvas节点返回null后续取width、height直接报错，