### PR TITLE
支持微信canvas type=2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@
 其中 `ec` 是一个我们在 `index.js` 中定义的对象，它使得图表能够在页面加载后被初始化并设置。`index.js` 的结构如下：
 
 ```js
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // 像素
   });
   canvas.setChart(chart);
 
@@ -113,6 +114,8 @@ Page({
 发布时，如果对文件大小要求更高，可以在 [ECharts 在线定制](http://echarts.baidu.com/builder.html)网页下载仅包含必要组件的包，并且选择压缩。
 
 下载的文件放在 `ec-canvas/echarts.js`，**注意一定需要重命名为 `echarts.js`**。
+
+此外，还可考虑使用微信小程序的[分包策略](https://developers.weixin.qq.com/miniprogram/dev/framework/subpackages/independent.html)
 
 ## 微信版本要求
 

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "pages":[
+  "pages": [
     "pages/index/index",
     "pages/bar/index",
     "pages/measureText/index",
@@ -25,11 +25,12 @@
     "pages/move/index",
     "pages/saveCanvas/index"
   ],
-  "window":{
-    "backgroundTextStyle":"light",
+  "window": {
+    "backgroundTextStyle": "light",
     "backgroundColor": "#eee",
     "navigationBarBackgroundColor": "#eee",
     "navigationBarTitleText": "ECharts 图表示例",
-    "navigationBarTextStyle":"black"
-  }
+    "navigationBarTextStyle": "black"
+  },
+  "sitemapLocation": "sitemap.json"
 }

--- a/ec-canvas/ec-canvas.js
+++ b/ec-canvas/ec-canvas.js
@@ -1,7 +1,33 @@
 import WxCanvas from './wx-canvas';
 import * as echarts from './echarts';
+const forceUseOldCanvas = false // 是否强制使用旧的canvas
 
 let ctx;
+
+function compareVersion(v1, v2) {
+  v1 = v1.split('.')
+  v2 = v2.split('.')
+  const len = Math.max(v1.length, v2.length)
+
+  while (v1.length < len) {
+    v1.push('0')
+  }
+  while (v2.length < len) {
+    v2.push('0')
+  }
+
+  for (let i = 0; i < len; i++) {
+    const num1 = parseInt(v1[i])
+    const num2 = parseInt(v2[i])
+
+    if (num1 > num2) {
+      return 1
+    } else if (num1 < num2) {
+      return -1
+    }
+  }
+  return 0
+}
 
 Component({
   properties: {
@@ -16,7 +42,7 @@ Component({
   },
 
   data: {
-
+    canUseNewCanvas: false,
   },
 
   ready: function () {
@@ -33,50 +59,125 @@ Component({
 
   methods: {
     init: function (callback) {
-      const version = wx.version.version.split('.').map(n => parseInt(n, 10));
-      const isValid = version[0] > 1 || (version[0] === 1 && version[1] > 9)
-        || (version[0] === 1 && version[1] === 9 && version[2] >= 91);
-      if (!isValid) {
-        console.error('微信基础库版本过低，需大于等于 1.9.91。'
-          + '参见：https://github.com/ecomfe/echarts-for-weixin'
-          + '#%E5%BE%AE%E4%BF%A1%E7%89%88%E6%9C%AC%E8%A6%81%E6%B1%82');
-        return;
+      const version = wx.getSystemInfoSync().SDKVersion
+
+      let canUseNewCanvas = compareVersion(version, '2.9.0') >= 0
+      if (forceUseOldCanvas) {
+        if (canUseNewCanvas) console.warn("开发者强制使用旧canvas,建议关闭")
+        canUseNewCanvas = false
       }
+      this.setData({ canUseNewCanvas: canUseNewCanvas })
+      if (canUseNewCanvas) {
+        console.log('微信基础库版本大于2.9.0，开始使用<canvas type="2d"/>');
+        // 2.9.0 可以使用 <canvas type="2d"></canvas>
+        this.initByNewWay(callback)
 
+      } else {
+
+        const isValid = compareVersion(version, '1.9.91') >= 0
+        if (!isValid) {
+          console.error('微信基础库版本过低，需大于等于 1.9.91。'
+            + '参见：https://github.com/ecomfe/echarts-for-weixin'
+            + '#%E5%BE%AE%E4%BF%A1%E7%89%88%E6%9C%AC%E8%A6%81%E6%B1%82');
+          return;
+        } else {
+          console.warn('建议将微信基础库调整大于等于2.9.0版本。升级后绘图将有更好性能');
+          this.initByOldWay(callback)
+        }
+
+      }
+    },
+
+    initByOldWay(callback) {
+      // 1.9.91 <= version < 2.9.0：原来的方式初始化
       ctx = wx.createCanvasContext(this.data.canvasId, this);
-
-      const canvas = new WxCanvas(ctx, this.data.canvasId);
+      const canvas = new WxCanvas(ctx, this.data.canvasId, false);
 
       echarts.setCanvasCreator(() => {
         return canvas;
       });
-
+      // const canvasDpr = wx.getSystemInfoSync().pixelRatio // 微信旧的canvas不能传入dpr
+      const canvasDpr = 1
       var query = wx.createSelectorQuery().in(this);
       query.select('.ec-canvas').boundingClientRect(res => {
         if (typeof callback === 'function') {
-          this.chart = callback(canvas, res.width, res.height);
+          this.chart = callback(canvas, res.width, res.height, canvasDpr);
         }
         else if (this.data.ec && typeof this.data.ec.onInit === 'function') {
-          this.chart = this.data.ec.onInit(canvas, res.width, res.height);
+          this.chart = this.data.ec.onInit(canvas, res.width, res.height, canvasDpr);
         }
         else {
           this.triggerEvent('init', {
             canvas: canvas,
             width: res.width,
-            height: res.height
+            height: res.height,
+            canvasDpr: canvasDpr // 增加了dpr，可方便外面echarts.init
           });
         }
       }).exec();
     },
 
-    canvasToTempFilePath(opt) {
-      if (!opt.canvasId) {
-        opt.canvasId = this.data.canvasId;
-      }
+    initByNewWay(callback) {
+      // version >= 2.9.0：使用新的方式初始化
+      const query = wx.createSelectorQuery().in(this)
+      query
+        .select('.ec-canvas')
+        .fields({ node: true, size: true })
+        .exec(res => {
+          const canvasNode = res[0].node
+          this.canvasNode = canvasNode
 
-      ctx.draw(true, () => {
-        wx.canvasToTempFilePath(opt, this);
-      });
+          const canvasDpr = wx.getSystemInfoSync().pixelRatio
+          const canvasWidth = res[0].width
+          const canvasHeight = res[0].height
+
+          const ctx = canvasNode.getContext('2d')
+
+          const canvas = new WxCanvas(ctx, this.data.canvasId, true, canvasNode)
+          echarts.setCanvasCreator(() => {
+            return canvas
+          })
+
+          if (typeof callback === 'function') {
+            this.chart = callback(canvas, canvasWidth, canvasHeight, canvasDpr)
+          } else if (this.data.ec && typeof this.data.ec.onInit === 'function') {
+            this.chart = this.data.ec.onInit(canvas, canvasWidth, canvasHeight, canvasDpr)
+          } else {
+            this.triggerEvent('init', {
+              canvas: canvas,
+              width: canvasWidth,
+              height: canvasHeight,
+              dpr: canvasDpr
+            })
+          }
+        })
+    },
+    canvasToTempFilePath(opt) {
+      const version = wx.getSystemInfoSync().SDKVersion
+      let canUseNewCanvas = compareVersion(version, '2.9.0') >= 0
+     
+      if (forceUseOldCanvas) canUseNewCanvas = false
+     
+      if (canUseNewCanvas) {
+        // 新版
+        const query = wx.createSelectorQuery().in(this)
+        query
+          .select('.ec-canvas')
+          .fields({ node: true, size: true })
+          .exec(res => {
+            const canvasNode = res[0].node
+            opt.canvas = canvasNode
+            wx.canvasToTempFilePath(opt)
+          })
+      } else {
+        // 旧的  
+        if (!opt.canvasId) {
+          opt.canvasId = this.data.canvasId;
+        }
+        ctx.draw(true, () => {
+          wx.canvasToTempFilePath(opt, this);
+        });
+      }
     },
 
     touchStart(e) {

--- a/ec-canvas/ec-canvas.wxml
+++ b/ec-canvas/ec-canvas.wxml
@@ -1,4 +1,4 @@
-<canvas class="ec-canvas" canvas-id="{{ canvasId }}"
-bindinit="init"
-bindtouchstart="{{ ec.disableTouch ? '' : 'touchStart' }}" bindtouchmove="{{ ec.disableTouch ? '' : 'touchMove' }}" bindtouchend="{{ ec.disableTouch ? '' : 'touchEnd' }}">
-</canvas>
+<!-- 新的：接口对其了H5 -->
+<canvas wx:if="{{canUseNewCanvas}}" type="2d" class="ec-canvas" canvas-id="{{ canvasId }}" bindinit="init" bindtouchstart="{{ ec.disableTouch ? '' : 'touchStart' }}" bindtouchmove="{{ ec.disableTouch ? '' : 'touchMove' }}" bindtouchend="{{ ec.disableTouch ? '' : 'touchEnd' }}"></canvas>
+<!-- 旧的 -->
+<canvas wx:else class="ec-canvas" canvas-id="{{ canvasId }}" bindinit="init" bindtouchstart="{{ ec.disableTouch ? '' : 'touchStart' }}" bindtouchmove="{{ ec.disableTouch ? '' : 'touchMove' }}" bindtouchend="{{ ec.disableTouch ? '' : 'touchEnd' }}"></canvas>

--- a/ec-canvas/wx-canvas.js
+++ b/ec-canvas/wx-canvas.js
@@ -1,11 +1,18 @@
 export default class WxCanvas {
-  constructor(ctx, canvasId) {
+  constructor(ctx, canvasId, isNew, canvasNode) {
     this.ctx = ctx;
     this.canvasId = canvasId;
     this.chart = null;
+    this.isNew = isNew
+    if (isNew) {
+      this.canvasNode = canvasNode;
+    }
+    else {
+      this._initStyle(ctx);
+    }
 
     // this._initCanvas(zrender, ctx);
-    this._initStyle(ctx);
+
     this._initEvent();
   }
 
@@ -19,7 +26,6 @@ export default class WxCanvas {
   //   if (!opt.canvasId) {
   //     opt.canvasId = this.canvasId;
   //   }
-
   //   return wx.canvasToTempFilePath(opt, this);
   // }
 
@@ -27,7 +33,7 @@ export default class WxCanvas {
     this.chart = chart;
   }
 
-  attachEvent () {
+  attachEvent() {
     // noop
   }
 
@@ -47,14 +53,14 @@ export default class WxCanvas {
   }
 
   _initStyle(ctx) {
-    var styles = ['fillStyle', 'strokeStyle', 'globalAlpha', 
+    var styles = ['fillStyle', 'strokeStyle', 'globalAlpha',
       'textAlign', 'textBaseAlign', 'shadow', 'lineWidth',
       'lineCap', 'lineJoin', 'lineDash', 'miterLimit', 'fontSize'];
 
     styles.forEach(style => {
       Object.defineProperty(ctx, style, {
         set: value => {
-          if (style !== 'fillStyle' && style !== 'strokeStyle' 
+          if (style !== 'fillStyle' && style !== 'strokeStyle'
             || value !== 'none' && value !== null
           ) {
             ctx['set' + style.charAt(0).toUpperCase() + style.slice(1)](value);
@@ -93,5 +99,23 @@ export default class WxCanvas {
         });
       };
     });
+  }
+
+  set width(w) {
+    if (this.canvasNode) this.canvasNode.width = w
+  }
+  set height(h) {
+    if (this.canvasNode) this.canvasNode.height = h
+  }
+
+  get width() {
+    if (this.canvasNode)
+      return this.canvasNode.width
+    return 0
+  }
+  get height() {
+    if (this.canvasNode)
+      return this.canvasNode.height
+    return 0
   }
 }

--- a/pages/bar/index.js
+++ b/pages/bar/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 let chart = null;
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 
@@ -131,7 +132,7 @@ Page({
   onReady() {
     setTimeout(function () {
       // 获取 chart 实例的方式
-      console.log(chart)
+      // console.log(chart)
     }, 2000);
   }
 });

--- a/pages/boxplot/index.js
+++ b/pages/boxplot/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/funnel/index.js
+++ b/pages/funnel/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/gauge/index.js
+++ b/pages/gauge/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/graph/index.js
+++ b/pages/graph/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/heatmap/index.js
+++ b/pages/heatmap/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/index/index.wxml
+++ b/pages/index/index.wxml
@@ -1,10 +1,10 @@
-<!--index.wxml-->
+<!-- index.wxml -->
 <view class="panel">
-  <view class="chart-with-img" wx:for="{{charts}}" wx:for-item="chart" wx:key="{{chart.id}}">
+  <view class="chart-with-img" wx:for="{{charts}}" wx:for-item="chart" wx:key="id">
     <image src="../../img/icons/{{chart.id}}.png" mode="aspectFit" bindtap="open" data-chart="{{chart}}"></image>
     {{chart.name}}
   </view>
-  <view class="chart-without-img" wx:for="{{chartsWithoutImg}}" wx:for-item="chart" wx:key="{{chart.id}}">
+  <view class="chart-without-img" wx:for="{{chartsWithoutImg}}" wx:for-item="chart" wx:key="id">
     <button bindtap="open" data-chart="{{chart}}">{{chart.name}}</button>
   </view>
 </view>

--- a/pages/k/index.js
+++ b/pages/k/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/lazyLoad/index.js
+++ b/pages/lazyLoad/index.js
@@ -122,7 +122,7 @@ Page({
   data: {
     ec: {
       // 将 lazyLoad 设为 true 后，需要手动初始化图表
-      lazyLoad: true 
+      lazyLoad: true
     },
     isLoaded: false,
     isDisposed: false
@@ -130,12 +130,13 @@ Page({
 
   // 点击按钮后初始化图表
   init: function () {
-    this.ecComponent.init((canvas, width, height) => {
+    this.ecComponent.init((canvas, width, height, dpr) => {
       // 获取组件的 canvas、width、height 后的回调函数
       // 在这里初始化图表
       const chart = echarts.init(canvas, null, {
         width: width,
-        height: height
+        height: height,
+        devicePixelRatio: dpr // new
       });
       setOption(chart);
 

--- a/pages/line/index.js
+++ b/pages/line/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 
@@ -60,7 +61,7 @@ function initChart(canvas, width, height) {
       type: 'line',
       smooth: true,
       data: [10, 30, 31, 50, 40, 20, 10]
-}]
+    }]
   };
 
   chart.setOption(option);

--- a/pages/map/index.js
+++ b/pages/map/index.js
@@ -3,10 +3,11 @@ import geoJson from './mapData.js';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/move/index.js
+++ b/pages/move/index.js
@@ -15,10 +15,11 @@ Page({
       // 就将 disableTouch 设为 true
       // disableTouch: true,
 
-      onInit: function (canvas, width, height) {
+      onInit: function (canvas, width, height, dpr) {
         const barChart = echarts.init(canvas, null, {
           width: width,
-          height: height
+          height: height,
+          devicePixelRatio: dpr // new
         });
         canvas.setChart(barChart);
         barChart.setOption(getBarOption());

--- a/pages/multiCharts/index.js
+++ b/pages/multiCharts/index.js
@@ -11,10 +11,11 @@ Page({
   },
   data: {
     ecBar: {
-      onInit: function (canvas, width, height) {
+      onInit: function (canvas, width, height, dpr) {
         const barChart = echarts.init(canvas, null, {
           width: width,
-          height: height
+          height: height,
+          devicePixelRatio: dpr // new
         });
         canvas.setChart(barChart);
         barChart.setOption(getBarOption());
@@ -24,10 +25,11 @@ Page({
     },
 
     ecScatter: {
-      onInit: function (canvas, width, height) {
+      onInit: function (canvas, width, height, dpr) {
         const scatterChart = echarts.init(canvas, null, {
           width: width,
-          height: height
+          height: height,
+          devicePixelRatio: dpr // new
         });
         canvas.setChart(scatterChart);
         scatterChart.setOption(getScatterOption());

--- a/pages/parallel/index.js
+++ b/pages/parallel/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/pie/index.js
+++ b/pages/pie/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 
@@ -69,7 +70,7 @@ Page({
   onReady() {
   },
 
-  echartInit (e) {
-    initChart(e.detail.canvas, e.detail.width, e.detail.height);
+  echartInit(e) {
+    initChart(e.detail.canvas, e.detail.width, e.detail.height, e.detail.dpr);
   }
 });

--- a/pages/radar/index.js
+++ b/pages/radar/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/sankey/index.js
+++ b/pages/sankey/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/saveCanvas/index.js
+++ b/pages/saveCanvas/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 let chart = null;
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 
@@ -128,16 +129,30 @@ Page({
   },
 
   onReady() {
+    // tips:正常逻辑不建议这么写，需要保证initChart之后再执行下载
     setTimeout(() => {
       this.save();
-    });
+    }, 1000);
   },
 
   save() {
     // 保存图片到临时的本地文件
     const ecComponent = this.selectComponent('#mychart-dom-save');
     ecComponent.canvasToTempFilePath({
-      success: res => console.log(res.tempFilePath),
+      success: res => {
+        console.log("tempFilePath:", res.tempFilePath)
+
+        // 临时文件不等于存入系统相册, 如果需要存入系统相册，e.g:
+        // wx.saveImageToPhotosAlbum({
+        //   filePath: res.tempFilePath || '',
+        //   success: res => {
+        //     console.log("success", res)
+        //   },
+        //   fail: res => {
+        //     console.log("fail", res)
+        //   }
+        // })
+      },
       fail: res => console.log(res)
     });
   }

--- a/pages/scatter/index.js
+++ b/pages/scatter/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/sunburst/index.js
+++ b/pages/sunburst/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
   var item1 = {

--- a/pages/themeRiver/index.js
+++ b/pages/themeRiver/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
 

--- a/pages/tree/index.js
+++ b/pages/tree/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
   var data1 = {

--- a/pages/treemap/index.js
+++ b/pages/treemap/index.js
@@ -2,10 +2,11 @@ import * as echarts from '../../ec-canvas/echarts';
 
 const app = getApp();
 
-function initChart(canvas, width, height) {
+function initChart(canvas, width, height, dpr) {
   const chart = echarts.init(canvas, null, {
     width: width,
-    height: height
+    height: height,
+    devicePixelRatio: dpr // new
   });
   canvas.setChart(chart);
   var data = [];

--- a/project.config.json
+++ b/project.config.json
@@ -8,9 +8,11 @@
 		"newFeature": true
 	},
 	"compileType": "miniprogram",
-	"libVersion": "2.0.0",
+	"libVersion": "2.5.1",
 	"appid": "wxee40007e9b62f5d0",
 	"projectname": "ECharts%20Demo",
+	"simulatorType": "wechat",
+	"simulatorPluginLibVersion": {},
 	"condition": {
 		"search": {
 			"current": -1,

--- a/sitemap.json
+++ b/sitemap.json
@@ -1,0 +1,7 @@
+{
+  "desc": "关于本文件的更多信息，请参考文档 https://developers.weixin.qq.com/miniprogram/dev/framework/sitemap.html",
+  "rules": [{
+  "action": "allow",
+  "page": "*"
+  }]
+}


### PR DESCRIPTION
主要改动点，在ec-canvas 的init方法里，判断用户的基础库版本，满足2.9.0都可直接使用 微信的canvas type=2d特性。开发者唯一需要注意是，与之前版本使用上不同的点，initChart 时候传入dpr。

