### PR TITLE
修复微信小程序基础库2.14.1闪退

### DIFF
--- a/ec-canvas/ec-canvas.js
+++ b/ec-canvas/ec-canvas.js
@@ -80,7 +80,7 @@ Component({
     init: function (callback) {
       const version = wx.getSystemInfoSync().SDKVersion
 
-      const canUseNewCanvas = compareVersion(version, '2.9.0') >= 0;
+      const canUseNewCanvas = (compareVersion(version, '2.9.0') >= 0)&& (compareVersion('2.14.1',version) != 0);
       const forceUseOldCanvas = this.data.forceUseOldCanvas;
       const isUseNewCanvas = canUseNewCanvas && !forceUseOldCanvas;
       this.setData({ isUseNewCanvas });


### PR DESCRIPTION
2.14.1强制采用旧canvas