### PR TITLE
feat: 因windows终端小程序不支持canvas2d，修改为在windows终端采用旧版canvas

### DIFF
--- a/ec-canvas/ec-canvas.js
+++ b/ec-canvas/ec-canvas.js
@@ -77,12 +77,20 @@ Component({
   },
 
   methods: {
-    init: function (callback) {
+    async init (callback) {
       const version = wx.getSystemInfoSync().SDKVersion
 
       const canUseNewCanvas = compareVersion(version, '2.9.0') >= 0;
       const forceUseOldCanvas = this.data.forceUseOldCanvas;
-      const isUseNewCanvas = canUseNewCanvas && !forceUseOldCanvas;
+      // const isUseNewCanvas = canUseNewCanvas && !forceUseOldCanvas;
+      const { platform } = await wx.getSystemInfo();
+			let isUseNewCanvas = canUseNewCanvas && !forceUseOldCanvas;
+			if (platform && /windows/i.test(platform)) {
+				isUseNewCanvas = false;
+			} else {
+				isUseNewCanvas = canUseNewCanvas && !forceUseOldCanvas;
+			}
+			this.setData({ isUseNewCanvas });
       this.setData({ isUseNewCanvas });
 
       if (forceUseOldCanvas && canUseNewCanvas) {


### PR DESCRIPTION
因windows终端小程序不支持canvas2d，修改为在windows终端采用旧版canvas，可以兼容在windows客户端打开的小程序