### PR TITLE
Update ec-canvas.js

### DIFF
--- a/ec-canvas/ec-canvas.js
+++ b/ec-canvas/ec-canvas.js
@@ -200,11 +200,15 @@ Component({
         var handler = this.chart.getZr().handler;
         handler.dispatch('mousedown', {
           zrX: touch.x,
-          zrY: touch.y
+          zrY: touch.y,
+          preventDefault: () => {},
+          stopPropagation: () => {},
         });
         handler.dispatch('mousemove', {
           zrX: touch.x,
-          zrY: touch.y
+          zrY: touch.y,
+          preventDefault: () => {},
+          stopPropagation: () => {},
         });
         handler.processGesture(wrapTouch(e), 'start');
       }
@@ -216,7 +220,9 @@ Component({
         var handler = this.chart.getZr().handler;
         handler.dispatch('mousemove', {
           zrX: touch.x,
-          zrY: touch.y
+          zrY: touch.y,
+          preventDefault: () => {},
+          stopPropagation: () => {},
         });
         handler.processGesture(wrapTouch(e), 'change');
       }
@@ -228,11 +234,15 @@ Component({
         var handler = this.chart.getZr().handler;
         handler.dispatch('mouseup', {
           zrX: touch.x,
-          zrY: touch.y
+          zrY: touch.y,
+          preventDefault: () => {},
+          stopPropagation: () => {},
         });
         handler.dispatch('click', {
           zrX: touch.x,
-          zrY: touch.y
+          zrY: touch.y,
+          preventDefault: () => {},
+          stopPropagation: () => {},
         });
         handler.processGesture(wrapTouch(e), 'end');
       }


### PR DESCRIPTION
echarts不知道哪个版本中添加了
function(t){t.preventDefault(),t.stopPropagation(),t.cancelBubble=!0}
这一段操作，t就是传入的参数，不添加这两个函数会因为报错导致无法拖动。
没仔细测试别的事件是否需要添加，索性全加上算了。